### PR TITLE
Game Timer Fix

### DIFF
--- a/MineSweeper/Pages/GamePage.xaml.cs
+++ b/MineSweeper/Pages/GamePage.xaml.cs
@@ -33,8 +33,13 @@ namespace MineSweeper.Pages
 
             _uiHelper = new UpdateUIHelper(MineFieldGrid);
 
+            _gameTimer.OnTimeChanged += (time) =>
+            {
+                Dispatcher.Invoke(() => _uiHelper.UpdateTimer(Timer, time));
+            };
+
             SetupBoard();
-            _gameTimer.StartTimer(Timer);
+            _gameTimer.StartTimer();
         }
 
         private void SetupBoard()
@@ -111,7 +116,7 @@ namespace MineSweeper.Pages
             _mineCount = MinePositions.Length;
             MineCounter.Text = _mineCount.ToString();
             Timer.Text = "0";
-            _gameTimer.StartTimer(Timer);
+            _gameTimer.ResetTimer();
         }
     }
 }

--- a/MineSweeper/Pages/GamePage.xaml.cs
+++ b/MineSweeper/Pages/GamePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using MineSweeper.Models;
 using MineSweeper.Services;
-using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/MineSweeper/Services/GameTimerService.cs
+++ b/MineSweeper/Services/GameTimerService.cs
@@ -1,23 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Controls;
-
-namespace MineSweeper.Services
+﻿internal class GameTimerService
 {
-    internal class GameTimerService
+    private bool _isRunning = false;
+    private int _time = 0;
+
+    public event Action<int>? OnTimeChanged; // notify UI helper
+
+    public async void StartTimer()
     {
-        public async void StartTimer(TextBlock timer)
+        if (_isRunning) return;
+        _isRunning = true;
+
+        while (_isRunning)
         {
-            int time = 0;
-            while (true)
-            {
-                await Task.Delay(1000);
-                time++;
-                timer.Text = time.ToString();
-            }
+            await Task.Delay(1000);
+            _time++;
+            OnTimeChanged?.Invoke(_time);
         }
+    }
+
+    public void ResetTimer()
+    {
+        _time = 0;
+        OnTimeChanged?.Invoke(_time);
     }
 }

--- a/MineSweeper/Services/UpdateUIHelper.cs
+++ b/MineSweeper/Services/UpdateUIHelper.cs
@@ -101,5 +101,9 @@ namespace MineSweeper.Services
             _cellButtonMap.Clear();
             _mineFieldGrid.Children.Clear();
         }
+        public void UpdateTimer(TextBlock timer, int time)
+        {
+            timer.Text = time.ToString();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -135,3 +135,25 @@ This refactor makes 'GamePage' smaller and focused, improves lookup performance
 by removing per-reveal grid searches, and sets up clear boundaries between
 logic, data, and UI responsibilities.
 
+
+## **Game Timer Fix**
+
+fix: prevent multiple timers on retry and move UI updates into helper
+
+- Updated GameTimerService:
+  - Added internal state (_isRunning, _time) to prevent multiple overlapping timers
+  - Exposed OnTimeChanged event to notify subscribers instead of directly updating UI
+  - Added ResetTimer() to reset time to 0 and trigger UI update
+
+- Updated UpdateUIHelper:
+  - Added UpdateTimer() method to centralize timer text updates
+
+- Updated GamePage:
+  - Subscribed to GameTimerService.OnTimeChanged and routed updates through UI helper
+  - Replaced duplicate timer start calls with ResetTimer()
+  - Ensured ResetButton resets both mines and timer cleanly
+
+This fix resolves the retry bug where multiple timers were stacking on reset,
+and maintains clear separation of concerns: timer logic in GameTimerService,
+UI rendering in UpdateUIHelper, and orchestration in GamePage.
+


### PR DESCRIPTION
fix: prevent multiple timers on retry and move UI updates into helper

- Updated GameTimerService:
  - Added internal state (_isRunning, _time) to prevent multiple overlapping timers
  - Exposed OnTimeChanged event to notify subscribers instead of directly updating UI
  - Added ResetTimer() to reset time to 0 and trigger UI update

- Updated UpdateUIHelper:
  - Added UpdateTimer() method to centralize timer text updates

- Updated GamePage:
  - Subscribed to GameTimerService.OnTimeChanged and routed updates through UI helper
  - Replaced duplicate timer start calls with ResetTimer()
  - Ensured ResetButton resets both mines and timer cleanly

This fix resolves the retry bug where multiple timers were stacking on reset, and maintains clear separation of concerns: timer logic in GameTimerService, UI rendering in UpdateUIHelper, and orchestration in GamePage.